### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ Flask==1.0.2
 pytest==3.7.1
 pytest-json-report==0.7.0
 python-dotenv==0.9.1
+jinja2<3.1.0
+itsdangerous==2.0.1
+werkzeug==2.0.3


### PR DESCRIPTION
To resolve import error issues while installing packages from pip install -r requirements.txt. 
 Installing from requirements.txt tends to install latest package versions which leads to following import errors:
1. ImportError: cannot import name 'escape' from 'jinja2'
2. ImportError: cannot import name ‘json’ from 'itsdangerous'
3. ImportError: cannot import name 'BaseResponse' from 'werkzeug.wrappers'